### PR TITLE
Use ESNext/ES7 property initializer syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react"]
+  "presets": ["react"],
+  "plugins": ["transform-class-properties"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -281,6 +281,27 @@
         "esutils": "2.0.2"
       }
     },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -308,6 +329,11 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -317,6 +343,17 @@
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "body-parser": "^1.18.2",
     "express": "^4.15.4",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -4,21 +4,12 @@ import Particles from 'react-particles-js';
 import Sonic from 'sonicnet';
 
 class App extends Component {
-  constructor() {
-    super();
-    this.state = {
-      input:"",
-      listening: false,
-      sending: false,
-    };
-    this.receiver = new Sonic.Receiver();
-    this.handleListeningClick = this.handleListeningClick.bind(this);
-    this.handleSubmitClick = this.handleSubmitClick.bind(this);
-    this.handleSendClick = this.handleSendClick.bind(this);
-    this.handleInputChange = this.handleInputChange.bind(this);
-    this.turnListenerOn = this.turnListenerOn.bind(this);
-    this.setupListenerForListening = this.setupListenerForListening.bind(this);
-  }
+  state = {
+    input: '',
+    listening: false,
+    sending: false,
+  };
+  receiver = new Sonic.Receiver();
 
   componentDidMount() {
     this.receiver.start(this.setupListenerForListening);
@@ -32,14 +23,14 @@ class App extends Component {
     });
   }
 
-  turnListenerOn() {
+  turnListenerOn = () => {
     if(this.state.sending === true)
       this.exitSendMode();
     this.setupListenerForListening();
     this.receiver.start();
   }
 
-  setupListenerForListening() {
+  setupListenerForListening = () => {
     this.setState({
       listening: true,
     })
@@ -50,7 +41,7 @@ class App extends Component {
     $('#listenSection').removeClass("off").addClass("on").children('#listening').html("");
   }
 
-  turnListenerOff() {
+  turnListenerOff = () => {
     this.receiver.stop();
     this.setState({
       listening: false
@@ -58,14 +49,14 @@ class App extends Component {
     $('#listenSection').removeClass("on").addClass("off").children('#listening').html("LISTEN");
   }
 
-  handleListeningClick() {
+  handleListeningClick = () => {
     if(this.state.listening === false)
       this.turnListenerOn();
     else
       this.turnListenerOff();
   }
 
-  handleSendClick() {
+  handleSendClick = () => {
     $('.hidden').removeClass('hidden').addClass('active');
     $('#sendButton').removeClass('active').addClass('hidden');
     $('#cancel').removeClass('transparent');
@@ -74,7 +65,7 @@ class App extends Component {
     this.setState({ sending: true, });
   }
 
-  exitSendMode() {
+  exitSendMode = () => {
     $('.active').removeClass('active').addClass('hidden');
     $('#sendButton').removeClass('hidden').addClass('active');
     $('#cancel').addClass('transparent');
@@ -86,7 +77,7 @@ class App extends Component {
     });
   }
 
-  handleSubmitClick() {
+  handleSubmitClick = () => {
     console.log('Sending message ', this.state.input );
     $.get('/url', {url: this.state.input}, data => {
       console.log('Received from api:', data);
@@ -95,12 +86,12 @@ class App extends Component {
     } );
   }
 
-  handleInputChange(event) {
+  handleInputChange = (event) => {
     this.setState({input: event.target.value});
     console.log('Input is:', this.state.input);
   }
 
-  render() {
+  render () {
     return (
         <div>
             <div id="background">


### PR DESCRIPTION
* install and setup babel plugin
* new syntax allows cleaner creation of React component classes
* can remove explicit binding of `this` to methods
* can also completely remove `constructor()`
* also fixes #10

For details, see
* [react documentation on event handling](https://facebook.github.io/react/docs/handling-events.html)
* [Babel documentation on property initializer syntax](https://babeljs.io/docs/plugins/transform-class-properties/)
* [blog post on React and ESNext classes](https://www.fullstackreact.com/articles/use-property-initializers-for-cleaner-react-components/)

Syntax is ESNext so is subject to change, but nonetheless seems very popular with React developers given how much nicer it makes the code.