### PR TITLE
Set default local port to 3000

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "server.js",
   "scripts": {
     "build": "webpack --watch --config webpack.config.js",
+    "start": "node server.js",
     "postinstall": "webpack --config webpack.config.js",
-    "start": "heroku local web"
+    "heroku": "heroku local web"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -37,5 +37,5 @@ const shorten = (req, res, next) => {
 app.get('/url', logreq, shorten);
 
 /******** RUN SERVER ********/
-const PORT = process.env.PORT;
+const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log("Listening on port ", PORT));


### PR DESCRIPTION
Previously, `heroku local web` had to be used for local testing to
ensure `process.env.PORT` was set correctly. Now, the port defaults to
`3000` if `process.env.PORT` is not set. This means that local testing
once again works with `node server.js` as well as `heroku local web`.

Local testing can now be run with:
* `npm start`/`npm run start`: local node server
* `npm run heroku`: local Heroku server (runs node too of course)